### PR TITLE
docs: add contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Stay up to date with new releases and projects, learn more about how to protect 
 - Follow us on [Twitter][twitter] to stay up to date with the latest news
 - Check out our [Openness Framework][openness] and [Product Management][product] on Github to see how we operate and give us feedback.
 
+### Contributors
+
+<a href="https://www.github.com/blindnet-io/blindnet.dev/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=blindnet-io/blindnet.dev"/>
+</a>
+
 ## License
 
 © Copyright 2020-2022 [blindnet](mailto:hello@blindnet.io)


### PR DESCRIPTION
add a automatically populated "contributors" section to the README

as soon as we have enough contributors, this should be merged and reproduced in other repositories (updating [the associated templates](https://github.com/blindnet-io/openness-framework/blob/main/OpenSource/template/))