### PR TITLE
docs: add structure to the feature list

### DIFF
--- a/docs/_partials/_features-list.mdx
+++ b/docs/_partials/_features-list.mdx
@@ -1,4 +1,4 @@
-- easy to integrate privacy enforcement
+- easy to integrate privacy management
   - white-label **Web Components** for all privacy settings
   - helpers libraries for easy **capture** of sensitive data with associated user consent
 - advanced sensitive data management

--- a/docs/_partials/_features-list.mdx
+++ b/docs/_partials/_features-list.mdx
@@ -1,0 +1,10 @@
+- easy to integrate privacy enforcement
+  - **capture** of sensitive data with associated user consent
+  - **users' privacy rights management**
+  - **privacy-aware** interface development
+- advanced sensitive data management
+  - **access management**
+  - secured **transfer** of sensitive data and associated user consent to compatible systems
+- data protection
+  - secured data **storage** and **automated** management
+  - end-to-end **encryption**

--- a/docs/_partials/_features-list.mdx
+++ b/docs/_partials/_features-list.mdx
@@ -1,10 +1,7 @@
 - easy to integrate privacy enforcement
-  - **capture** of sensitive data with associated user consent
-  - **users' privacy rights management**
-  - **privacy-aware** interface development
+  - white-label **Web Components** for all privacy settings
+  - helpers libraries for easy **capture** of sensitive data with associated user consent
 - advanced sensitive data management
-  - **access management**
-  - secured **transfer** of sensitive data and associated user consent to compatible systems
-- data protection
   - secured data **storage** and **automated** management
   - end-to-end **encryption**
+  - secured **transfer** of sensitive data and associated user consent to compatible systems

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,6 +2,7 @@
 title: Introduction
 sidebar_position: 1
 ---
+import DevkitFeaturesList from '@site/docs/_partials/_features-list.mdx';
 
 Welcome to blindnet devkit's documentation :wave:
 
@@ -21,13 +22,7 @@ With this purpose in mind, it is mostly defined (and yet not limited to) two ver
 Several independent components are here to cover these two workflows and more.
 You can use these components separately. Yet, they work wonders together, supporting:
 
-- **capture** of sensitive data with their associated user consent
-- **users' privacy rights management**
-- secured data **storage** and **automated management**
-- end-to-end **encryption**
-- **access management**
-- secured **transfer** of sensitive data and associated user consent to compatible systems
-- **privacy-aware** interfaces development
+<DevkitFeaturesList />
 
 Our [Quick Start tutorial](./tutorial) is here to give you a simple entry point to familiarize yourself with these components and understand how they play together.
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,8 @@ import GitHubButton from 'react-github-btn';
 import OpenSourceSVG from './illustrations/open-source.svg';
 import FilesSentSVG from './illustrations/files-sent.svg';
 import ScienceSVG from './illustrations/alien-science.svg';
+// @ts-ignore
+import DevkitFeaturesList from '@site/docs/_partials/_features-list.mdx';
 
 function Banner() {
   return (
@@ -71,14 +73,7 @@ function DevKit() {
             It is made of several independent, yet cohesive Open Source libraries, services and tools together enabling confidentiality,
             control and compliance with regulation, by supporting:
           </p>
-          <ul>
-            <li><strong>capture</strong> of sensitive data with their associated user consent</li>
-            <li><strong>users' privacy rights management</strong></li>
-            <li>secured data <strong>storage</strong> and <strong>automated</strong> management</li>
-            <li>end-to-end <strong>encryption</strong></li>
-            <li><strong>access management</strong></li>
-            <li>secured <strong>transfer</strong> of sensitive data and associated user consent to compatible systems</li>
-          </ul>
+          <DevkitFeaturesList />
           <p>
             Follow our <a href="/docs/encryption/quickstart">Quick Start</a> guide to understand how the components plays together, and
             explore the <a href="/docs/">documentation</a> to learn more.


### PR DESCRIPTION
move the list of devkit features to a partial, and update it in both the home page and general introduction in docs to add an additional level of structure following Milan's feedback