### PR TITLE
docs(tutorial): update PCE 

### DIFF
--- a/docs/02-tutorial.mdx
+++ b/docs/02-tutorial.mdx
@@ -124,7 +124,7 @@ Here, you only need to run one script for everything: building the project, crea
 ./scripts/start.sh
 ```
 
-After this script has been executed successfully, a new PCE instance should be available on your machine, with its API exposed on port `3000`.
+After this script has been executed successfully, a new PCE instance should be available on your machine, with its API exposed on port `9000`.
 
 You can verify the service is running and available by calling the `health` endpoint:
 

--- a/docs/02-tutorial.mdx
+++ b/docs/02-tutorial.mdx
@@ -172,7 +172,7 @@ Refer to the [associated documentation](/docs/computation/configuration) for all
 
 ### Using the Privacy Computation Engine 
 
-You can now directly call the standalone Privacy Computation Engine [REST API](https://devkit-pce-staging.azurewebsites.net/swagger/) from your applications and services.
+You can now directly call the standalone Privacy Computation Engine [REST API](https://stage.computing.blindnet.io/swagger/) from your applications and services.
 
 However, the true strength of the blindnet devkit comes when combining its various components, thus drastically improving your developer experience and productivity while giving you access to additional features.
 

--- a/docs/02-tutorial.mdx
+++ b/docs/02-tutorial.mdx
@@ -27,22 +27,152 @@ We strongly recommend reading the linked sections of the documentation for more 
 
 :::
 
-## 1. Initial Configuration
+## 1. Set Up a Privacy Computation Engine
 
 The [Privacy Computation Engine](./computation) is the core of blindnet devkit.
 It is a simple service you can interact with via a Rest API to create and track your users' [Privacy Requests](/docs/references/lexicon#privacy-request).
 
 Using the Privacy Computation Engine goes into three steps:
 
-1. **[App Management](/docs/access-management/set-up)**: register and obtain an application id;
+1. **[Set Up a UID](/docs/access-management/set-up)**: register and obtain a unique ID for your system;
 2. **[Configuration](./computation/configuration)**: configure the service using its configuration API;
-3. **Development**: call the Privacy Computation Engine from your registered application to handle Privacy Requests
+3. **Development**: call the Privacy Computation Engine from your registered applications to handle Privacy Requests
 
-Step _(1) App Management_ and _(2) Configuration_ don't need to be addressed for this tutorial.
+:::caution System ID
 
-<PreConfiguredPCE />
+In its current stage of development, the PCE is provided with a preconfigured system ID.
+As a consequence, step _(1) Set Up a UID_ doesn't need to be addressed for this tutorial.
 
-Step _(3) Development_ can be achieved directly by calling the standalone Privacy Computation Engine [REST API](https://devkit-pce-staging.azurewebsites.net/swagger/).
+:::
+
+### Pre-requisites
+
+For this tutorial, we'll simply use the privacy-computation-engine code source repository, as it is provided with several tools to help you get started.
+
+To use these tools, you'll first need to install and setup a **Java Development Kit**, **sbt**, and **docker-compose** on your machine.
+
+:::tip Quick Install with SDKMAN
+
+Mac OS and Linux users can directly install sbt with the recommended JDK using [SDKMAN](https://sdkman.io/), with the following commands:
+
+```bash
+# IF you need to install SDKMAN quickly
+curl -s "https://get.sdkman.io" | bash
+
+# install the recommended JDK
+sdk install java $(sdk list java | grep -o "\b8\.[0-9]*\.[0-9]*\-tem" | head -1)
+
+# install sbt
+sdk install sbt
+```
+
+As indicated in the sbt documentation, using SDKMAN has two advantages.
+
+1. it will install the official packaging by Eclipse Adoptium, as opposed to the “mystery meat OpenJDK builds“.
+2. it will install tgz packaging of sbt that contains all JAR files. (DEB and RPM packages do not to save bandwidth)
+
+:::
+
+#### Java Development Kit
+
+For the JDK, we recommend Eclipse Adoptium Temurin JDK 8, 11, or 17, following sbt own recommendation, but any JDK should do (if you encounter an issue with any other JDK, please don't hesitate to open an issue).
+
+The Eclipse Adoptium Temurin JDK is available for Windows (via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/)), Mac OS (via [homebrew](https://docs.brew.sh/Manpage)) and many Linux distributions (via RPM and DEB packages).
+Refer to [the installation documentation](https://adoptium.net/installation) for all details.
+Arch-based Linux distributions can also install the Eclipse Temurin JDK via the associated non-official [AUR package](https://aur.archlinux.org/packages/jdk-temurin).
+
+#### sbt
+
+The PCE is developed with Scala.
+As this tutorial will require you to build the PCE from source, we'll use sbt, the de-facto build tool in the Scala community.
+
+The sbt [download](https://www.scala-sbt.org/download.html) page will give you instructions to install it:
+
+- on any system via [`cs setup`](https://www.scala-lang.org/download/), the Scala installer powered by Coursier
+- on Mac OS via SDKMAN or homebrew
+- on Windows via a msi file, Chocolatey or Scoop
+- on Linux via a deb or rpm package, or a universal package
+
+Refer to the more extensive [sbt "installing sbt" documentation](https://www.scala-sbt.org/1.x/docs/Setup.html) for more information.
+
+#### docker-compose
+
+In the following steps, we'll also use a docker-compose configuration to run the PCE with its required dependencies (including a PostgreSQL instance).
+
+You'll therefore either need [Docker Desktop](https://docs.docker.com/desktop/) (which provides a full Docker installation, including Compose) or the [Compose standalone](https://docs.docker.com/compose/install/other/) installation.
+
+:::caution Remember the Start the Docker Daemon
+
+Make sure the Docker daemon is running and accessible to your current user before anything.
+
+When using Systemd, you can run `sudo systemctl status docker` to check the status of the Docker daemon, and `sudo systemctl start docker` to start it.
+
+:::
+
+### Setup and Run the PCE
+
+Now, to clone the [privacy-computation-engine](https://github.com/blindnet-io/privacy-computation-engine/) repository, run:
+
+```bash
+git clone git@github.com:blindnet-io/privacy-computation-engine.git
+cd privacy-computation-engine
+```
+
+Here, you only need to run one script for everything: building the project, creating a dedicated Docker image, starting a Postgres instance, execute database migrations and run the Privacy Computation Engine:
+
+```bash
+./scripts/start.sh
+```
+
+After this script has been executed successfully, a new PCE instance should be available on your machine, with its API exposed on port `3000`.
+
+You can verify the service is running and available by calling the `health` endpoint:
+
+```bash
+curl -v localhost:9000/v0/health
+```
+
+:::caution Remember to stop it
+
+After completing this tutorial, make sure to stop and clean up all associated docker containers with:
+
+```bash
+./scripts/stop.sh
+```
+
+:::
+
+### Configuration
+
+Now, your PCE instance needs some configuration.
+
+Here again, you only need one script: [`./scripts/init-config.sh`](https://github.com/blindnet-io/privacy-computation-engine/blob/develop/scripts/init-config.sh).
+
+This script includes all the different API calls needed to configure the PCE instance, with default configuration values.
+
+Just execute this script, and your PCE instance is good to go.
+
+```bash
+./scripts/init-config.sh
+```
+
+You can make a [`GET /configure/general-info`](https://devkit-pce-staging.azurewebsites.net/swagger/#/Configuration/getV0ConfigureGeneral-info) request to check the preconfigured general information configuration:
+
+```bash
+curl -v localhost:9000/v0/configure/general-info
+```
+
+:::note Real-World Scenario
+
+In a real-world scenario, you can use the exact same script to configure your PCE instance in one go, after replacing the example values with the ones which fit your real context.
+
+Refer to the [associated documentation](/docs/computation/configuration) for all details.
+
+:::
+
+### Using the Privacy Computation Engine 
+
+You can now directly call the standalone Privacy Computation Engine [REST API](https://devkit-pce-staging.azurewebsites.net/swagger/) from your applications and services.
 
 However, the true strength of the blindnet devkit comes when combining its various components, thus drastically improving your developer experience and productivity while giving you access to additional features.
 


### PR DESCRIPTION
> **Warning** **Depends on**:
> - [ ] https://github.com/blindnet-io/privacy-computation-engine/pull/17
> - [ ] https://github.com/blindnet-io/privacy-computation-engine/pull/19

Update the first step of the introductory tutorial to run a local instance of the PCE instead of the prebuilt one.

For now, we ask to build the project from source, but after that, https://github.com/blindnet-io/devrel-management/issues/72 should allow people to directly run the docker image without any prerequisites.

Next step (use the local instance in PRCI and DCI) is blocked by https://github.com/blindnet-io/privacy-components-web/pull/149 